### PR TITLE
Update nextRTC.js

### DIFF
--- a/nextRTC.js
+++ b/nextRTC.js
@@ -63,7 +63,8 @@ var NextRTC = function NextRTC(config) {
     };
 
     this.setChannelReady = function () {
-        for (var w in that.waiting) {
+        for (var i=0;i<that.waiting.length; i++) {
+            var w = that.waiting[i];
             console.log("req: " + w);
             that.signaling.send(w);
         }


### PR DESCRIPTION
There was in error in setChannelReady.  The 'in' operator in javascript will iterate over members of an object (not just array elements) as opposed to how it works in java.  So my client was sending 'addAll' to the server and crashing the connection.   (Add all wasn't waiting to be sent, but was a method of the empty array).   I changed to an old school loop.